### PR TITLE
Replaced hexdump for util-linux on RedHat-like

### DIFF
--- a/src/internal/bh_depinstall.sh
+++ b/src/internal/bh_depinstall.sh
@@ -8,6 +8,7 @@ bashacks_depinstall() {
         sPktManager="zypper -q --non-interactive install"
     elif which yum >/dev/null; then # RedHat-like
         sPktManager="yum -qy install"
+        sPkt=${sPkt/hexdump/util-linux}
     elif which brew >/dev/null; then # OS X
         sPktManager="brew install"
     fi


### PR DESCRIPTION
Hi,

I've replaced `hexdump` in `$sPkt` for `util-linux` since `hexdump` on RedHat-like systems is provided by package `util-linux`. Otherwise `yum` would fail with an error ("Error: Unable to find a match: hexdump").

Regards && sonniges Wochenende :)

Jens